### PR TITLE
Fix logic error in setup, when not using /usr/local.

### DIFF
--- a/setup
+++ b/setup
@@ -326,7 +326,7 @@ EOF
 check_prefix() {
     local prefix="$1"
     shift
-    if [ "$prefix" != "/usr/local" ]; then
+    if [ "$prefix" = "/usr/local" ]; then
         debug 1 "prefix is /usr/local, trying with defaults"
     else
         set -- PKG_CONFIG_PATH="$prefix/lib/pkgconfig"


### PR DESCRIPTION
The 'check_prefix' function just had an inverted logic error.
It would only set the PKG_CONFIG_PATH if the install location
of squashfs-tools-ng *was* /usr/local.