### PR TITLE
Use personal squashfs-tools-ng branch with a fix for backslash in paths.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ $(SQUASHTOOL).static: $(GO_LIB_FILES) $(GO_TOOL_FILES)
 
 test: $(SQUASHTOOL) images
 	./$(SQUASHTOOL) test-main noroot.squashfs
+	./$(SQUASHTOOL) list noroot.squashfs
 
 images: $(SQUASHFS_IMAGES)
 

--- a/make-test-squashfs
+++ b/make-test-squashfs
@@ -85,6 +85,10 @@ mkdir perms/no-read.d
 touch perms/no-read.d/file.txt
 chmod 111 perms/no-read.d
 
+
+mkdir oddfellows/
+echo "systemd-x" > "oddfellows/system-systemd\x2dcryptsetup.slice"
+
 #mkdir perms/no-read.d
 #touch perms/no-read.d/file.txt
 #chmod 000 perms/no-read.d

--- a/setup
+++ b/setup
@@ -3,7 +3,7 @@
 _GO_VER=1.14.8
 VERBOSITY=0
 TEMP_D=""
-SQFSNG_GIT="${SQFS_NG_GIT:-https://github.com/AgentD/squashfs-tools-ng.git}"
+SQFSNG_GIT="${SQFS_NG_GIT:-https://github.com/smoser/squashfs-tools-ng.git}"
 SQFSNG_REF="${SQFS_REF-origin/fixes-1.0.0}"
 [ -n "$HOME" ] || export HOME=$(echo ~)
 


### PR DESCRIPTION
A bug in squashfs-tools-ng meant that squashfs files that contained
filenames with a backslash would fail to extract.

This does a few things:
 * Temporarily change the git repo and branch to point at smoser's personal
   branch, so we can get a build before upstream gets this into their
   fixes-1.0.0 branch. My pull request is at
      https://github.com/AgentD/squashfs-tools-ng/pull/78
   That will also have to land in the stable branch before we
   can move back to upstream.

 * Adds a file with a backslash in its name to the squash image used
   in test.
 * runs 'list' as part of 'make test', which would expose the failure.