### PR TITLE
Switch back to upstream for squashfs-tools-ng source.

### DIFF
--- a/setup
+++ b/setup
@@ -3,7 +3,7 @@
 _GO_VER=1.14.8
 VERBOSITY=0
 TEMP_D=""
-SQFSNG_GIT="${SQFS_NG_GIT:-https://github.com/smoser/squashfs-tools-ng.git}"
+SQFSNG_GIT="${SQFS_NG_GIT:-https://github.com/AgentD/squashfs-tools-ng.git}"
 SQFSNG_REF="${SQFS_REF-origin/fixes-1.0.0}"
 [ -n "$HOME" ] || export HOME=$(echo ~)
 


### PR DESCRIPTION
We had used a smoser branch of squashfs-tools-ng in order to land a fix
for #6.  This changes back to building against the upstream git repo
rather than smoser's.

Fixes #9.