### PR TITLE
Cleanup/try dlopen

### DIFF
--- a/libcfsops.go
+++ b/libcfsops.go
@@ -1,0 +1,146 @@
+package squashfs
+
+// #cgo LDFLAGS: -ldl
+// #include <stdlib.h>
+// #include <dlfcn.h>
+// #include <sys/types.h>
+// #include <sys/stat.h>
+// #include <fcntl.h>
+// #include <unistd.h>
+// #include <errno.h>
+// #include <stdio.h>
+//
+// int
+// my_mknod(void *f, const char *s, mode_t mode, dev_t dev)
+// {
+//   int (*xmknod)(int, const char *, mode_t mode, dev_t dev);
+//   printf("trying %s %d %d\n", s, (int)mode, (int)dev);
+//
+//   xmknod = (int (*)(int, const char *, mode_t mode, dev_t dev))f;
+//   return xmknod(_MKNOD_VER_LINUX, s, mode, dev);
+// }
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func GetLibcFsOps() (FsOps, error) {
+	x := LibcFsOps{}
+	err := x.init()
+	return &x, err
+}
+
+type LibcFsOps struct {
+	chmod  unsafe.Pointer
+	chown  unsafe.Pointer
+	xmknod unsafe.Pointer
+}
+
+func (l *LibcFsOps) Chmod(name string, mode os.FileMode) error {
+	return os.Chmod(name, mode)
+}
+
+func (l *LibcFsOps) Chown(name string, uid, gid int) error {
+	return os.Chown(name, uid, gid)
+}
+
+func (l *LibcFsOps) Mknod(path string, info FileInfo) error {
+	stat := info.Sys().(syscall.Stat_t)
+	d := C.dev_t(stat.Rdev)
+	m := C.mode_t(DefaultFilePerm)
+	p := C.CString(path)
+
+	fmt.Printf("path=%v m=%v d=%v\n", p, m, d)
+	eno := C.my_mknod(l.xmknod, p, m, d)
+	if eno != 0 {
+		return fmt.Errorf("Got error for %s: %d", path, eno)
+	}
+	return nil
+}
+
+func (l *LibcFsOps) init() error {
+	handle, err := GetHandle([]string{"libfakeroot-sysv.so"})
+	if err != nil {
+		return err
+	}
+
+	// libc 'mknod' is a macro , the function call is actually __xmknod
+	l.xmknod, err = handle.GetSymbolPointer("__xmknod")
+	if err != nil {
+		return err
+	}
+
+	l.chmod, err = handle.GetSymbolPointer("chmod")
+	if err != nil {
+		return err
+	}
+
+	l.chown, err = handle.GetSymbolPointer("chown")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// copied from https://github.com/coreos/pkg/dlopen
+
+var ErrSoNotFound = errors.New("unable to open a handle to the library")
+
+// LibHandle represents an open handle to a library (.so)
+type LibHandle struct {
+	Handle  unsafe.Pointer
+	Libname string
+}
+
+// GetHandle tries to get a handle to a library (.so), attempting to access it
+// by the names specified in libs and returning the first that is successfully
+// opened. Callers are responsible for closing the handler. If no library can
+// be successfully opened, an error is returned.
+func GetHandle(libs []string) (*LibHandle, error) {
+	for _, name := range libs {
+		libname := C.CString(name)
+		defer C.free(unsafe.Pointer(libname))
+		handle := C.dlopen(libname, C.RTLD_LAZY)
+		if handle != nil {
+			h := &LibHandle{
+				Handle:  handle,
+				Libname: name,
+			}
+			return h, nil
+		}
+	}
+	return nil, ErrSoNotFound
+}
+
+// GetSymbolPointer takes a symbol name and returns a pointer to the symbol.
+func (l *LibHandle) GetSymbolPointer(symbol string) (unsafe.Pointer, error) {
+	sym := C.CString(symbol)
+	defer C.free(unsafe.Pointer(sym))
+
+	C.dlerror()
+	p := C.dlsym(l.Handle, sym)
+	e := C.dlerror()
+	if e != nil {
+		return nil, fmt.Errorf("error resolving symbol %q: %v", symbol, errors.New(C.GoString(e)))
+	}
+
+	return p, nil
+}
+
+// Close closes a LibHandle.
+func (l *LibHandle) Close() error {
+	C.dlerror()
+	C.dlclose(l.Handle)
+	e := C.dlerror()
+	if e != nil {
+		return fmt.Errorf("error closing %v: %v", l.Libname, errors.New(C.GoString(e)))
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is an attempt to avoid forks to 'chmod', 'chown' and 'mknod' when running under fakeroot.

the dlopen code is copied from https://github.com/coreos/pkg/blob/master/dlopen/dlopen_example.go .

As it is right now, it is segfaulting:

```
$ make
go build ./...
cd squashtool/ && go build -o squashtool -ldflags '-X main.version=0.0.1-21-g75b48d0' ./...

$ fakeroot sh -c './squashtool/squashtool.static extract --devs root.squashfs x &&
 ls -l x/dev'
Extracting squashfs file root.squashfs to x.
ops=<nil>
is this fakeroot? true
path=0x2960d70 m=420 d=2048
trying x/dev/block-dev-sda 420 2048
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0x800 pc=0x7fb33c393042]

runtime stack:
runtime.throw(0x7c7965, 0x2a)
        /usr/lib/go-1.16/src/runtime/panic.go:1117 +0x72
runtime.sigpanic()
        /usr/lib/go-1.16/src/runtime/signal_unix.go:718 +0x2e5

goroutine 1 [syscall]:
runtime.cgocall(0x5e1770, 0xc00018e810, 0xc00000ac00)
        /usr/lib/go-1.16/src/runtime/cgocall.go:154 +0x5b fp=0xc00018e7e0 sp=0xc00018e7a8 pc=0x4056db
github.com/anuvu/squashfs._Cfunc_my_mknod(0x7fb33c392fc0, 0x2960d70, 0x1a4, 0x800, 0x0)
        _cgo_gotypes.go:466 +0x48 fp=0xc00018e810 sp=0xc00018e7e0 pc=0x5379c8
github.com/anuvu/squashfs.(*LibcFsOps).Mknod.func1(0xc00000e168, 0x2960d70, 0x1a4, 0x800, 0xc00018ea10)
        /home/smoser/src/squashfs/libcfsops.go:59 +0x72 fp=0xc00018e850 sp=0xc00018e810 pc=0x53d712
github.com/anuvu/squashfs.(*LibcFsOps).Mknod(0xc00000e168, 0xc00001a1c8, 0x13, 0xc00001a180, 0x12, 0x0, 0x40061b4,
 0x0, 0xed866c83f, 0x97d560, ...)
        /home/smoser/src/squashfs/libcfsops.go:59 +0x247 fp=0xc00018ea50 sp=0xc00018e850 pc=0x538887
github.com/anuvu/squashfs.(*Extractor).extractBlockDevice.func1(0xc0001a60b0, 0xc00001a1c8)
        /home/smoser/src/squashfs/extract.go:265 +0xa2 fp=0xc00018eb28 sp=0xc00018ea50 pc=0x53d4e2
github.com/anuvu/squashfs.(*Extractor).doCreate(0xc0001a60b0, 0xc00001a1c8, 0x13, 0xc00001a180, 0x12, 0x0, 0x40061b4, 0x0, 0xed866c83f, 0x97d560, ...)
        /home/smoser/src/squashfs/extract.go:395 +0x12c fp=0xc00018ebd0 sp=0xc00018eb28 pc=0x536eec
github.com/anuvu/squashfs.(*Extractor).extractBlockDevice(0xc0001a60b0, 0xc00001a180, 0x12, 0xc00001a180, 0x12, 0x0, 0x40061b4, 0x0, 0xed866c83f, 0x97d560, ...)
        /home/smoser/src/squashfs/extract.go:264 +0x245 fp=0xc00018ecf8 sp=0xc00018ebd0 pc=0x5359a5
github.com/anuvu/squashfs.(*Extractor).extract(0xc0001a60b0, 0xc00001a180, 0x12, 0xc00001a180, 0x12, 0x0, 0x40061b4, 0x0, 0xed866c83f, 0x97d560, ...)
        /home/smoser/src/squashfs/extract.go:177 +0x1005 fp=0xc00018efc0 sp=0xc00018ecf8 pc=0x534b45
github.com/anuvu/squashfs.(*Extractor).extract-fm(0xc00001a180, 0x12, 0xc00001a180, 0x12, 0x0, 0x40061b4, 0x0, 0xed866c83f, 0x97d560, 0xc0000aa880, ...)
        /home/smoser/src/squashfs/extract.go:143 +0x9d fp=0xc00018f058 sp=0xc00018efc0 pc=0x53e99d
github.com/anuvu/squashfs.walk(0xc00001a180, 0x12, 0xc00001a180, 0x12, 0x0, 0x40061b4, 0x0, 0xed866c83f, 0x97d560, 0xc0000aa880, ...)
        /home/smoser/src/squashfs/squash.go:103 +0x59d fp=0xc00018f298 sp=0xc00018f058 pc=0x539d1d
github.com/anuvu/squashfs.walk(0xc000018c68, 0x4, 0xc000018c68, 0x4, 0x45, 0x800041fd, 0x0, 0xed866c83f, 0x97d560, 0xc0000aa800, ...)
        /home/smoser/src/squashfs/squash.go:128 +0x445 fp=0xc00018f4d8 sp=0xc00018f298 pc=0x539bc5
github.com/anuvu/squashfs.walk(0x7b8f49, 0x1, 0x7b8f49, 0x1, 0x93, 0x800041fd, 0x0, 0xed866c83f, 0x97d560, 0xc0000aa740, ...)
        /home/smoser/src/squashfs/squash.go:128 +0x445 fp=0xc00018f718 sp=0xc00018f4d8 pc=0x539bc5
github.com/anuvu/squashfs.(*SquashFs).Walk(0xc0001a60c0, 0x7b8f49, 0x1, 0xc00018f9a8, 0x1, 0x1)
        /home/smoser/src/squashfs/squash.go:93 +0x2a5 fp=0xc00018f8f8 sp=0xc00018f718 pc=0x539745
github.com/anuvu/squashfs.(*Extractor).Extract(0xc0001a60b0, 0x974ac8, 0x9)
        /home/smoser/src/squashfs/extract.go:125 +0x1f8 fp=0xc00018f9e8 sp=0xc00018f8f8 pc=0x5337f8
main.extractMain(0xc0000aa700, 0x8, 0xe)
        /home/smoser/src/squashfs/squashtool/main.go:102 +0x765 fp=0xc00018fcd8 sp=0xc00018f9e8 pc=0x5df925
github.com/urfave/cli/v2.(*Command).Run(0xc0001a2360, 0xc0000aa480, 0x0, 0x0)
        /home/smoser/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/command.go:164 +0x4dd fp=0xc00018fdb0 sp=0xc00018fcd8 pc=0x5c9fdd
github.com/urfave/cli/v2.(*App).RunContext(0xc000001980, 0x802330, 0xc0000180a0, 0xc0000120a0, 0x5, 0x5, 0x0, 0x0)
        /home/smoser/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:306 +0x810 fp=0xc00018fed8 sp=0xc00018fdb0 pc=0x5c76b0
github.com/urfave/cli/v2.(*App).Run(...)
        /home/smoser/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:215
main.main()
        /home/smoser/src/squashfs/squashtool/main.go:244 +0x595 fp=0xc00018ff88 sp=0xc00018fed8 pc=0x5e13b5
runtime.main()
        /usr/lib/go-1.16/src/runtime/proc.go:225 +0x256 fp=0xc00018ffe0 sp=0xc00018ff88 pc=0x43a076
runtime.goexit()
        /usr/lib/go-1.16/src/runtime/asm_amd64.s:1371 +0x1 fp=0xc00018ffe8 sp=0xc00018ffe0 pc=0x46c521
smoser@atom-lab-4:~/src/squashfs$ 
```