### PR TITLE
Use os.Lchown rather than os.Chown in extraction.

### DIFF
--- a/extract.go
+++ b/extract.go
@@ -48,7 +48,7 @@ func (g GoFsOps) Chmod(name string, mode os.FileMode) error {
 }
 
 func (g GoFsOps) Chown(name string, uid, gid int) error {
-	return os.Chown(name, uid, gid)
+	return os.Lchown(name, uid, gid)
 }
 
 func (g GoFsOps) Mknod(path string, info FileInfo) error {


### PR DESCRIPTION
In the re-work of the previos commit, I inadvertantly changed from
using 'os.Lchown' to 'os.Chown'.