### PR TITLE
Fix bad substitution error in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-VERSION := $(shell x=$$(git describe --tags --long 2>/dev/null) && echo $${x\#v} || echo unknown)
+HASH = \#
+VERSION := $(shell x=$$(git describe --tags --long 2>/dev/null) && echo $${x$(HASH)v} || echo unknown)
 VERSION_SUFFIX := $(shell [ -z "$$(git status --porcelain --untracked-files=no 2>/dev/null)" ] || echo -dirty)
 VERSION_FULL := $(VERSION)$(VERSION_SUFFIX)
 X_VERSION := -X main.version=$(VERSION_FULL)


### PR DESCRIPTION
GNU make 4.3 changed behavior and using it you'd see:

   /bin/sh: 1: Bad substitution

That came from the setting of the VERSION variable.

I did some debug and filed a gnu make bug 62831 [1].

The solution that works in both cases and seems more robust is to use a variable 'HASH'.

The other change here was to just drop use of a '#' that wasn't really necessary in creation of subs.mk.  There, it only served to remove a leading space.

--
[1] https://savannah.gnu.org/bugs/index.php?62381