### PR TITLE
Upload on a tag.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,3 +53,11 @@ jobs:
         name: binaries
         path: bin/
         if-no-files-found: error
+
+    - name: Release bin
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          bin/squashtool
+          bin/squashtool.dynamic


### PR DESCRIPTION
This should upload the static squashtool on tagged builds.