### PR TITLE
Fix version output by checking out tags.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Install Deps
       run: |


### PR DESCRIPTION
actions/checkout@v3 by default will only checkout a single commit. That means that 'git describe --tags' will not find anything. In order to get tags, you have to use 'fetch-depth: 0' per
 https://github.com/actions/checkout